### PR TITLE
fix: item textures in inventory break after loading resourcepack

### DIFF
--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -24,6 +24,7 @@ declare const customEvents: import('typed-emitter').default<{
   digStart (): void
   gameLoaded (): void
   mineflayerBotCreated (): void
+  resourcesUpdated (): void
   search (q: string): void
   activateItem (item: Item, slot: number, offhand: boolean): void
   hurtAnimation (): void

--- a/src/inventoryWindows.ts
+++ b/src/inventoryWindows.ts
@@ -26,6 +26,7 @@ import { getItemModelName } from './resourcesManager'
 const loadedImagesCache = new Map<string, HTMLImageElement>()
 const cleanLoadedImagesCache = () => {
   loadedImagesCache.delete('blocks')
+  loadedImagesCache.delete('items')
 }
 
 let lastWindow: ReturnType<typeof showInventory>
@@ -55,7 +56,10 @@ export const onGameLoad = (onLoad) => {
       allImagesLoadedState.value = true
     }, 0)
   }
-  viewer.world.renderUpdateEmitter.on('textureDownloaded', checkIfLoaded)
+  viewer.world.renderUpdateEmitter.on('textureDownloaded', () => {
+    checkIfLoaded()
+    cleanLoadedImagesCache()
+  })
   checkIfLoaded()
 
   PrismarineItem = PItem(version)

--- a/src/react/HotbarRenderApp.tsx
+++ b/src/react/HotbarRenderApp.tsx
@@ -192,12 +192,14 @@ const HotbarInner = () => {
       }
       touchStart = 0
     })
+    customEvents.on('resourcesUpdated', upHotbarItems)
 
     return () => {
       inv.destroy()
       controller.abort()
       unsub2()
       viewer.world.renderUpdateEmitter.off('textureDownloaded', upHotbarItems)
+      customEvents.off('resourcesUpdated', upHotbarItems)
     }
   }, [])
 

--- a/src/resourcePack.ts
+++ b/src/resourcePack.ts
@@ -609,6 +609,7 @@ const updateTextures = async (progressReporter = createConsoleLogProgressReporte
       viewer.world.rerenderAllChunks?.()
     }
   }
+  customEvents.emit('resourcesUpdated')
 }
 
 export const resourcepackReload = async (version) => {


### PR DESCRIPTION
This fixes that applying a resource pack with custom item textures/model data would break item textures (both of modified items and Vanilla ones)

With the bug vs. after the fix:
![image](https://github.com/user-attachments/assets/1332e1ce-3efe-4b48-8d7b-98da8c78e701) ![image](https://github.com/user-attachments/assets/ca81ca9b-56b7-4fba-92e3-968bc0c630fd)

![image](https://github.com/user-attachments/assets/b8bfd5b5-d06a-4dfc-810f-43937b1647e6) ![image](https://github.com/user-attachments/assets/288cca93-9628-4266-b086-8357a8d6d0fd)

![image](https://github.com/user-attachments/assets/d869d7b4-fe56-446f-9cea-65993af2a8fb) ![image](https://github.com/user-attachments/assets/eb8d8007-b868-407c-8810-4aab10aa2939)